### PR TITLE
Improve readme to include info from Modrinth page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 [![Modrinth](https://img.shields.io/modrinth/dt/chunks-fade-in?style=for-the-badge&color=green&logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAABvFBMVEUAAAD%2FAP8AojwA6f%2F%2F%2BAAA%2F%2FYA%2F3zC8wAA2FkA21MA2VwA0VoA1lcA11YA6FH%2FAP8A0V4A1U8A0lkA1lMA2VYAzmIAylkA008AzlwAy1IA2FkA2GMA1VgA1VIA1VoAzkwAy2AA004A1VEA3VsAzFoA110A12wA110A3VYA1W4Av1EAz0gA22wAzoMA3EsA2W4A%2F0AA%2BlAA%2F4QAtDkA%2FyQA%2F80AhqoiEMX%2FpAAA02AA2FgA3WEA3VoA32oA214A2V0A1VgA1GYA21oA21IAzFEA0l4A1FsA1VgA2WEAzVAA0FYA0FEAz2EA2E8A1WIA11oA1mEA0l0A0lUA2mAA1lwAylUAz1cA0mMA1lAA41cA1UwA21sA41oA0lgA4F4Az1cAyEsA1l0A4l8A3lYAzloA6WUA0EsAyEsA2FAA1jwAyF4Az1oA524A2VEA0VwA9VkAv1cA2UIA4mcA5H0A2zoAzjEAx0wA7mAAxV4A%2FG8A2l8A1E0A10wAxF4AwDQAy0sAtxcAyWIAtkAO1QAA8VoAqHwA%2FzwA33AAtVIA0YkgtQAA%2F8W2wgAA%2F6UA7u7%2FiwAAs%2F%2BAALMgYAD%2FACRxTWCJAAAAlHRSTlMABBMLCAYFBero4d7CuRUI6%2Bnj4N%2Fe29vW1by7t7eyrKuilZSHhm5mW1pZVVFBPTkaGA4NCwoKCAXy8e%2Fr6Ofm5uXl4%2BPh4eHc3NnZ2NjX19bW0czIvba0raWkoqKfkpCLiYSDgn59fXx8eHRra2RkZGRhYF1dW1hUU1NTTUlFREM5ODclIyIgHxwYFhURDwsKCggHjU6V5wAAAP5JREFUGNMFwQNixAAABMCNT0nOtm3Vtm3btm1%2FuDOgAQiHHusdG0sBaQ4MssFBeYMulnE6rvIAvos7jVrF5DmVtquMfo4AETE1e5Nf3HvmcaVSdgSkrJJ5irid4S8gLNaaSQS6FPfY6ymvOP5kyIG2fbiVs7jprHbFi4DoaxmHzbiOS0kfSeD3BVvqIVj0EfbU1J34CLmmqbDGjJEqt7ddWtdvl8tXmeXSKRy0GppqPA6JRuYjn3lZGIJT2nEiPmxsxjl2rcTyCiKk1y5RBRoiOVemi9LAm79XqlgIJvIBlWEbLLLInQ3Xq5VjiNqu%2FxgABPC0O8GPFn6SOdD4BwrbMVMNbnOUAAAAAElFTkSuQmCC)](https://modrinth.com/mod/chunks-fade-in)
 [![CurseForge](https://cf.way2muchnoise.eu/full_720811_downloads.svg?badge_style=for_the_badge)](https://www.curseforge.com/minecraft/mc-mods/chunks-fade-in)
 
-## Features
-Adds bedrock-like chunk fade in animation and chunk animations like in ChunkAnimator mod! For more details, please visit modrinth page.
+No more chunks appearing right in front of you out of nowhere! This mod adds Bedrock Edition like chunk fade in, similar to [Fade in Chunks](https://modrinth.com/mod/fade-in-chunks). It also adds chunk animations that work with Sodium! Other chunk animation mods like [ChunkAnimator](https://www.curseforge.com/minecraft/mc-mods/chunk-animator), [Chunkimator](https://modrinth.com/mod/chunkimator), [Animated Chunks](https://modrinth.com/mod/animated-chunks), and [Smooth Chunks](https://modrinth.com/mod/smooth-chunks) don't work with Sodium.
+
+## Showcase Video
+[![Youtube Video](http://img.youtube.com/vi/CanA5ADOis0/0.jpg)](https://www.youtube.com/watch?v=CanA5ADOis0)
+
+### Flexible configuration with Mod Menu support!
+![Mod Menu Config](readme-assets/config.png)
 
 ## Versions
-- 1.19.x
+- `1.19`-`1.19.2`
 
 ## Dependencies
-- sodium 0.4.x
+- Sodium `0.4.x`


### PR DESCRIPTION
Your readme seems to direct the reader to Modrinth for additional info, so I included all that info in the github readme. I think the problem was that you couldn't embed the youtube video in github but could in Modrinth? I've left a thumbnail image that links to the video for now.
