### PR TITLE
Move readme icon to the right of text

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@
 [![Modrinth](https://img.shields.io/modrinth/dt/chunks-fade-in?style=for-the-badge&color=green&logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAABvFBMVEUAAAD%2FAP8AojwA6f%2F%2F%2BAAA%2F%2FYA%2F3zC8wAA2FkA21MA2VwA0VoA1lcA11YA6FH%2FAP8A0V4A1U8A0lkA1lMA2VYAzmIAylkA008AzlwAy1IA2FkA2GMA1VgA1VIA1VoAzkwAy2AA004A1VEA3VsAzFoA110A12wA110A3VYA1W4Av1EAz0gA22wAzoMA3EsA2W4A%2F0AA%2BlAA%2F4QAtDkA%2FyQA%2F80AhqoiEMX%2FpAAA02AA2FgA3WEA3VoA32oA214A2V0A1VgA1GYA21oA21IAzFEA0l4A1FsA1VgA2WEAzVAA0FYA0FEAz2EA2E8A1WIA11oA1mEA0l0A0lUA2mAA1lwAylUAz1cA0mMA1lAA41cA1UwA21sA41oA0lgA4F4Az1cAyEsA1l0A4l8A3lYAzloA6WUA0EsAyEsA2FAA1jwAyF4Az1oA524A2VEA0VwA9VkAv1cA2UIA4mcA5H0A2zoAzjEAx0wA7mAAxV4A%2FG8A2l8A1E0A10wAxF4AwDQAy0sAtxcAyWIAtkAO1QAA8VoAqHwA%2FzwA33AAtVIA0YkgtQAA%2F8W2wgAA%2F6UA7u7%2FiwAAs%2F%2BAALMgYAD%2FACRxTWCJAAAAlHRSTlMABBMLCAYFBero4d7CuRUI6%2Bnj4N%2Fe29vW1by7t7eyrKuilZSHhm5mW1pZVVFBPTkaGA4NCwoKCAXy8e%2Fr6Ofm5uXl4%2BPh4eHc3NnZ2NjX19bW0czIvba0raWkoqKfkpCLiYSDgn59fXx8eHRra2RkZGRhYF1dW1hUU1NTTUlFREM5ODclIyIgHxwYFhURDwsKCggHjU6V5wAAAP5JREFUGNMFwQNixAAABMCNT0nOtm3Vtm3btm1%2FuDOgAQiHHusdG0sBaQ4MssFBeYMulnE6rvIAvos7jVrF5DmVtquMfo4AETE1e5Nf3HvmcaVSdgSkrJJ5irid4S8gLNaaSQS6FPfY6ymvOP5kyIG2fbiVs7jprHbFi4DoaxmHzbiOS0kfSeD3BVvqIVj0EfbU1J34CLmmqbDGjJEqt7ddWtdvl8tXmeXSKRy0GppqPA6JRuYjn3lZGIJT2nEiPmxsxjl2rcTyCiKk1y5RBRoiOVemi9LAm79XqlgIJvIBlWEbLLLInQ3Xq5VjiNqu%2FxgABPC0O8GPFn6SOdD4BwrbMVMNbnOUAAAAAElFTkSuQmCC)](https://modrinth.com/mod/chunks-fade-in)
 [![CurseForge](https://cf.way2muchnoise.eu/full_720811_downloads.svg?badge_style=for_the_badge)](https://www.curseforge.com/minecraft/mc-mods/chunks-fade-in)
 
-<p align="center">
-    <img width="200" src="readme-assets/icon.png" alt="Chunks fade in">
-</p>
+<img width="200" src="readme-assets/icon.png" align="right" alt="Chunks fade in icon">
 
 This simple mod adds Bedrock Edition-like fade-in animation for chunks. And also (if you want to) motion animation like in [ChunkAnimator] mod! No more chunks appearing right in front of you out of nowhere!  
 Unlike other similar mods like [ChunkAnimator], [Chunkimator], [Animated Chunks] and [Smooth Chunks], it works perfectly fine with Sodium!


### PR DESCRIPTION
A rather subjective change I guess. I think this better lays out the content, rather than having huge empty spaces to the sides of a centred icon.