### PR TITLE
Make Sodium DefaultChunkRenderer mixin less fragile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.1-SNAPSHOT'
+	id 'fabric-loom' version '1.6-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.parallel = true
 # Fabric Properties
 minecraft_version = 1.20.1
 yarn_mappings = 1.20.1+build.1
-loader_version = 0.14.21
+loader_version = 0.15.7
 
 # Mod Properties
 mod_version = 1.0.5-1.20.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/koteinik/chunksfadein/mixin/chunk/DefaultChunkRendererMixin.java
+++ b/src/main/java/com/koteinik/chunksfadein/mixin/chunk/DefaultChunkRendererMixin.java
@@ -1,12 +1,10 @@
 package com.koteinik.chunksfadein.mixin.chunk;
 
-import java.util.Iterator;
-
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import com.koteinik.chunksfadein.config.Config;
 import com.koteinik.chunksfadein.extensions.ChunkShaderInterfaceExt;
@@ -25,19 +23,18 @@ import me.jellysquid.mods.sodium.client.render.chunk.region.RenderRegion;
 import me.jellysquid.mods.sodium.client.render.chunk.shader.ChunkShaderInterface;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
 import me.jellysquid.mods.sodium.client.render.viewport.CameraTransform;
-import me.jellysquid.mods.sodium.client.util.iterator.ByteIterator;
 
 @Mixin(value = DefaultChunkRenderer.class, remap = false)
 public class DefaultChunkRendererMixin {
-    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer;executeDrawBatch", shift = At.Shift.BEFORE), locals = LocalCapture.CAPTURE_FAILHARD)
+    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer;executeDrawBatch", shift = At.Shift.BEFORE))
     private void modifyChunkRender(ChunkRenderMatrices matrices,
-            CommandList commandList,
-            ChunkRenderListIterable renderLists,
-            TerrainRenderPass renderPass,
-            CameraTransform camera,
-            CallbackInfo ci, boolean useBlockFaceCulling, ChunkShaderInterface shader,
-            Iterator<ChunkRenderList> iterator,
-            ChunkRenderList renderList, RenderRegion region) {
+                                   CommandList commandList,
+                                   ChunkRenderListIterable renderLists,
+                                   TerrainRenderPass renderPass,
+                                   CameraTransform camera,
+                                   CallbackInfo ci,
+                                   @Local(ordinal = 0) ChunkShaderInterface shader,
+                                   @Local(ordinal = 0) RenderRegion region) {
         if (!Config.isModEnabled || shader == null)
             return;
 
@@ -45,7 +42,7 @@ public class DefaultChunkRendererMixin {
         uploadToBuffer(commandList, shader, region);
     }
 
-    @Inject(method = "fillCommandBuffer", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer;addDrawCommands", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
+    @Inject(method = "fillCommandBuffer", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer;addDrawCommands", shift = At.Shift.AFTER))
     private static void modifyFillCommandBuffer(MultiDrawBatch batch,
             RenderRegion region,
             SectionRenderDataStorage renderDataStorage,
@@ -53,8 +50,11 @@ public class DefaultChunkRendererMixin {
             CameraTransform camera,
             TerrainRenderPass pass,
             boolean useBlockFaceCulling,
-            CallbackInfo ci, ByteIterator iterator, int originX, int originY, int originZ, int sectionIndex, int x,
-            int y, int z, long pMeshData, int slices) {
+            CallbackInfo ci,
+            @Local(name = "sectionIndex") int sectionIndex,
+            @Local(name = "chunkX") int x,
+            @Local(name = "chunkY") int y,
+            @Local(name = "chunkZ") int z) {
         if (!Config.isModEnabled)
             return;
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
     "chunksfadein.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.21",
+    "fabricloader": ">=0.15.7",
     "minecraft": ">=1.20.1",
     "java": ">=17",
     "sodium": "0.5.x"


### PR DESCRIPTION
Currently, your mod injects into the Sodium `DefaultChunkRenderer` mixin class to run custom fading functionality, and captures necessary information using Mixin's `LocalCapture` mechanism. Unfortunately, that is very fragile, because it breaks as soon as a local variable is added anywhere but at the end of the original set of variables. This is exactly what happens with Embeddium 0.3.19+, as I had to add an extra variable to implement a renderer feature needed for translucency sorting.

Fortunately, there is a rather simple solution: the MixinExtras `@Local` annotation allows capturing specific variables that are needed, rather than needing to hardcode a list. Using this in combination with capturing variables by name allows the mixin to be refactored so that it will not be affected by any additions/removals of variables that Chunks Fade In doesn't need.

I tested and the new mixin works fine with both Sodium 0.5.1 and Embeddium 0.3.19, even though the latter has an extra variable. Fabric Loom & Loader were bumped to enable using MixinExtras as shipped by Loader without needing to jar-in-jar it within the mod itself.

A similar (or the same) change should be applied for 1.20.2+. 