### PR TITLE
[1.20.1] Add compatability for SkinShuffle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings = 1.20.1+build.1
 loader_version = 0.15.7
 
 # Mod Properties
-mod_version = 1.0.6-1.20.1
+mod_version = 1.0.7-1.20.1
 maven_group = com.koteinik
 archives_base_name = chunksfadein
 

--- a/src/main/java/com/koteinik/chunksfadein/extensions/SodiumWorldRendererExt.java
+++ b/src/main/java/com/koteinik/chunksfadein/extensions/SodiumWorldRendererExt.java
@@ -1,5 +1,10 @@
 package com.koteinik.chunksfadein.extensions;
 
+import me.jellysquid.mods.sodium.client.render.chunk.RenderSectionManager;
+import org.jetbrains.annotations.Nullable;
+
 public interface SodiumWorldRendererExt {
     float[] getAnimationOffset(int x, int y, int z);
+    @Nullable
+    RenderSectionManager getRenderSectionManager();
 }

--- a/src/main/java/com/koteinik/chunksfadein/mixin/entity/EntityRendererMixin.java
+++ b/src/main/java/com/koteinik/chunksfadein/mixin/entity/EntityRendererMixin.java
@@ -26,6 +26,10 @@ public class EntityRendererMixin {
         if (renderer == null)
             return;
 
+        if(((SodiumWorldRendererExt) renderer).getRenderSectionManager() == null) {
+            return;
+        }
+
         float[] offset = ((SodiumWorldRendererExt) renderer).getAnimationOffset(
                 chunkPos.getX(),
                 chunkPos.getY(),

--- a/src/main/java/com/koteinik/chunksfadein/mixin/entity/ItemFrameEntityRendererMixin.java
+++ b/src/main/java/com/koteinik/chunksfadein/mixin/entity/ItemFrameEntityRendererMixin.java
@@ -29,6 +29,10 @@ public class ItemFrameEntityRendererMixin {
         if (renderer == null)
             return;
 
+        if(((SodiumWorldRendererExt) renderer).getRenderSectionManager() == null) {
+            return;
+        }
+
         float[] offset = ((SodiumWorldRendererExt) renderer).getAnimationOffset(
                 chunkPos.getX(),
                 chunkPos.getY(),

--- a/src/main/java/com/koteinik/chunksfadein/mixin/entity/SodiumWorldRendererMixin.java
+++ b/src/main/java/com/koteinik/chunksfadein/mixin/entity/SodiumWorldRendererMixin.java
@@ -2,8 +2,10 @@ package com.koteinik.chunksfadein.mixin.entity;
 
 import java.util.SortedSet;
 
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -35,6 +37,11 @@ public class SodiumWorldRendererMixin implements SodiumWorldRendererExt {
         return ((RenderSectionManagerExt) renderSectionManager).getAnimationOffset(x, y, z);
     }
 
+    @Override
+    public @Nullable RenderSectionManager getRenderSectionManager() {
+        return renderSectionManager;
+    }
+
     @Inject(method = "renderBlockEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/util/math/MatrixStack;translate(DDD)V", shift = Shift.AFTER, remap = true), locals = LocalCapture.CAPTURE_FAILHARD)
     private static void modifyRenderTileEntities(MatrixStack matrices,
             BufferBuilderStorage bufferBuilders,
@@ -48,6 +55,10 @@ public class SodiumWorldRendererMixin implements SodiumWorldRendererExt {
             BlockEntity entity, CallbackInfo ci) {
         if (!Config.isModEnabled || !entity.hasWorld() || !Config.isAnimationEnabled)
             return;
+
+        if(((SodiumWorldRendererExt) instance()).getRenderSectionManager() == null) {
+            return;
+        }
 
         ChunkSectionPos chunkPos = ChunkSectionPos.from(entity.getPos());
 


### PR DESCRIPTION
This should fix any issues with other mods that have dummy players/dummy worlds.

I've bumped the version in gradle.properties as well, please publish a release as soon as you can :+1: